### PR TITLE
chore(docs): fix AutoCompleteTag label

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ function App() {
               tags.map((tag, tid) => (
                 <AutoCompleteTag
                   key={tid}
-                  label={tag.label}
+                  label={tag.value}
                   onRemove={tag.onRemove}
                 />
               ))

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,7 +51,7 @@ function App() {
                 tags.map((tag, tid) => (
                   <AutoCompleteTag
                     key={tid}
-                    label={tag.label}
+                    label={tag.value}
                     onRemove={tag.onRemove}
                     disabled={tag.label === "japan"}
                   />


### PR DESCRIPTION
Updated `README` and `/example` to fix the AutoCompleteTag label not showing

Closes #55 