### PR TITLE
Fixed issue with styles in AutoCompleteGroupTitle not being overridden

### DIFF
--- a/src/autocomplete-group.tsx
+++ b/src/autocomplete-group.tsx
@@ -40,7 +40,7 @@ export const AutoCompleteGroup = forwardRef<AutoCompleteGroupProps, "div">(
 
 export const AutoCompleteGroupTitle = forwardRef<FlexProps, "div">(
   (props, ref) => {
-    return <Flex {...props} {...baseTitleStyles} ref={ref} />;
+    return <Flex {...baseTitleStyles} {...props} ref={ref} />;
   }
 );
 


### PR DESCRIPTION
Mentioned in comments for #67 

baseStyle props were applied after the props - making any matching styles set by the baseStyles override the props.