### PR TITLE
Exposes original value object to onSelectOption

### DIFF
--- a/src/helpers/items.ts
+++ b/src/helpers/items.ts
@@ -22,7 +22,7 @@ export const setEmphasis = (children: any, query: string) => {
   return newChildren;
 };
 
-export const getItemList = (children: ReactNode) => {
+export const getItemList = (children: ReactNode): Item[] => {
   const itemChildren = getChildrenDeep(
     children,
     (child: any) => child?.type?.displayName === "AutoCompleteItem"
@@ -35,7 +35,7 @@ export const getItemList = (children: ReactNode) => {
     const finObj = isDefined(itemObj.label)
       ? itemObj
       : { ...itemObj, label: value };
-    return { ...finObj, value };
+    return { ...finObj, value, originalValue: itemObj.value };
   });
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface Item {
   itemVal?: any;
   noFilter?: boolean;
   creatable?: boolean;
+  originalValue?: any;
 }
 
 export type UseAutoCompleteProps = Partial<{


### PR DESCRIPTION
Added a new property `originalValue` to `Item` in order to expose the original value that was passed in. Fixes #117 and is a follow-up enhancement to #60.  This is important since it allows you to now be able to access the other values inside the original value from the `onSelectOption` callback.

Example of item with `originalValue` property.
<img width="810" alt="Screen Shot 2022-02-04 at 7 51 27 PM" src="https://user-images.githubusercontent.com/70533701/152627758-ee8f9554-b80c-4449-85bd-02437da4b2fb.png">

