### PR TITLE
Modify 'fixed' prop to show item regardless of both filter and maxSuggestions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,6 +866,17 @@ val => val;
     <td>&mdash;&mdash;&mdash;</td>
 </tr>
 <tr>
+    <td>alwaysShow</td>
+    <td>
+
+    boolean
+
+</td>
+    <td>Make an item visible at all times, regardless of filtering or maxSuggestions</td>
+    <td>No</td>
+    <td>&mdash;&mdash;&mdash;</td>
+</tr>
+<tr>
     <td>_fixed</td>
     <td>
 

--- a/README.md
+++ b/README.md
@@ -861,17 +861,6 @@ val => val;
     boolean
 
 </td>
-    <td>Make an item visible at all times, regardless of filtering</td>
-    <td>No</td>
-    <td>&mdash;&mdash;&mdash;</td>
-</tr>
-<tr>
-    <td>alwaysShow</td>
-    <td>
-
-    boolean
-
-</td>
     <td>Make an item visible at all times, regardless of filtering or maxSuggestions</td>
     <td>No</td>
     <td>&mdash;&mdash;&mdash;</td>

--- a/src/autocomplete-item.tsx
+++ b/src/autocomplete-item.tsx
@@ -14,6 +14,7 @@ export interface AutoCompleteItemProps extends FlexProps {
   value: any;
   label?: string;
   fixed?: boolean;
+  alwaysShow?: boolean;
   _focus?: CSSObject | any;
   disabled?: boolean;
   _fixed?: CSSObject;

--- a/src/autocomplete-item.tsx
+++ b/src/autocomplete-item.tsx
@@ -14,7 +14,6 @@ export interface AutoCompleteItemProps extends FlexProps {
   value: any;
   label?: string;
   fixed?: boolean;
-  alwaysShow?: boolean;
   _focus?: CSSObject | any;
   disabled?: boolean;
   _fixed?: CSSObject;

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -96,6 +96,7 @@ export function useAutoComplete(
     .filter(
       i =>
         i.fixed ||
+        i.alwaysShow ||
         runIfFn(
           autoCompleteProps.filter || defaultFilterMethod,
           query,
@@ -104,7 +105,7 @@ export function useAutoComplete(
         ) ||
         listAll
     )
-    .filter((_, index) => (maxSuggestions ? index < maxSuggestions : true));
+    .filter((i, index) => (maxSuggestions ? i.alwaysShow || index < maxSuggestions : true));
 
   // Add Creatable to Filtered List
   const creatableArr: Item[] = creatable

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -96,7 +96,6 @@ export function useAutoComplete(
     .filter(
       i =>
         i.fixed ||
-        i.alwaysShow ||
         runIfFn(
           autoCompleteProps.filter || defaultFilterMethod,
           query,
@@ -105,7 +104,7 @@ export function useAutoComplete(
         ) ||
         listAll
     )
-    .filter((i, index) => (maxSuggestions ? i.alwaysShow || index < maxSuggestions : true));
+    .filter((i, index) => (maxSuggestions ? i.fixed || index < maxSuggestions : true));
 
   // Add Creatable to Filtered List
   const creatableArr: Item[] = creatable


### PR DESCRIPTION
As it stands, `fixed` is filtered out of the suggestions if these two conditions are met:
- there exists a maxSuggestions limit
- the `fixed` item index > maxSuggestions


My proposal is to keep that functionality but add another prop `alwaysShow` that behaves similar to `fixed` except it shows in suggestions regardless of maxSuggestions limit.