### PR TITLE
feat: :guitar: add hidePlaceholder prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,6 +772,20 @@ RefObject<HTMLInputElement>
     <td>No<br></td>
     <td>&mdash;&mdash;&mdash;</td>
   </tr>
+  <tr>
+    <td>hidePlaceholder</td>
+    <td>boolean</td>
+    <td>hides the placeholder when children is not an empty array. intended usage for
+
+```js
+<AutoComplete multiple creatable />
+```
+
+  </td>
+    <td>No<br></td>
+    <td>false</td>
+
+  </tr>
 
 </tbody>
 </table>

--- a/src/autocomplete-input.tsx
+++ b/src/autocomplete-input.tsx
@@ -18,6 +18,7 @@ import { UseAutoCompleteReturn } from "./types";
 export interface AutoCompleteInputProps extends Omit<InputProps, "children"> {
   children?: MaybeRenderProp<{ tags: UseAutoCompleteReturn["tags"] }>;
   wrapStyles?: SystemStyleObject;
+  hidePlaceholder?: boolean;
 }
 
 export const AutoCompleteInput = forwardRef<AutoCompleteInputProps, "input">(
@@ -31,15 +32,29 @@ export const AutoCompleteInput = forwardRef<AutoCompleteInputProps, "input">(
 
     // const ref = useMergeRefs(forwardedRef, inputRef);
 
-    const { children: childrenProp, isInvalid, ...rest } = props;
+    const {
+      children: childrenProp,
+      isInvalid,
+      hidePlaceholder,
+      ...rest
+    } = props;
 
     const themeInput: any = useMultiStyleConfig("Input", props);
 
-    const { wrapper, input: inputProps } = getInputProps(rest, themeInput);
+    let { wrapper, input: inputProps } = getInputProps(rest, themeInput);
     const { ref: wrapperRef, ...wrapperProps } = wrapper;
     const ref = useMergeRefs(forwardedRef, inputRef);
 
     const children = runIfFn(childrenProp, { tags });
+    if (hidePlaceholder) {
+      inputProps = {
+        ...inputProps,
+        placeholder:
+          Array.isArray(children) && children.length
+            ? undefined
+            : inputProps.placeholder,
+      };
+    }
 
     const simpleInput = (
       <Input isInvalid={isInvalid} {...(inputProps as any)} ref={ref} />


### PR DESCRIPTION
This adds a `hidePlaceholder` prop to the `AutoCompleteInput` component. 

It allows the placeholder to be hidden when the children array is not empty. This is useful in the following example:

```ts
// example/src/App.tsx

import { Flex, FormControl, FormLabel } from "@chakra-ui/react";
import * as React from "react";
import {
  AutoComplete,
  AutoCompleteInput, AutoCompleteTag
} from "../../src/index";

function App() {
  return (
    <Flex pt="48" justify="center" align="center" w="full">
      <FormControl>
        <FormLabel htmlFor="select-role">Default</FormLabel>
        <AutoComplete multiple creatable onChange={vals => console.log(vals)}>
          <AutoCompleteInput
            placeholder="Enter email addresses.."
            variant="outline"
            hidePlaceholder
          >
            {({ tags }) =>
              tags.map((tag, tid) => (
                <AutoCompleteTag
                  key={tid}
                  label={tag.label}
                  onRemove={tag.onRemove}
                />
              ))
            }
          </AutoCompleteInput>
        </AutoComplete>
      </FormControl>
    </Flex>
  );
}

export default App;
```  