### PR TITLE
fix: creatable list

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "@chakra-ui/react-utils": "^2.0.5",
     "@chakra-ui/tag": "^2.0.8",
     "@chakra-ui/utils": "^2.0.8",
-    "react-nanny": "2.14.0"
+    "react-nanny": "2.15.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7809,10 +7809,10 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-nanny@2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/react-nanny/-/react-nanny-2.14.0.tgz#c53afa8cd9612ca0eee57a35e0d38b65f76445a4"
-  integrity sha512-lX+SNWlpbIhN4h3zJQAtRqr7AXwldmgKxJ8e+eChFvMQISsZmHaR2SJujb3u1S6fpC5pUnYKsdbtwZXUG/4Qjw==
+react-nanny@2.15.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/react-nanny/-/react-nanny-2.15.0.tgz#9472984af45761263b92b209f925e773fd761653"
+  integrity sha512-fn6tAnJ+UEdD0pq5YytlZJb5XmjVcvXoxq3i2r1o/BavgipwRWsw7oOXNJ8bJd33iedlkNyAQMXVC6qTl0Hv4A==
 
 react-refresh@^0.14.0:
   version "0.14.0"


### PR DESCRIPTION
Fix for when using creatable, rest of the list is not shown.
[Issue](https://github.com/anubra266/choc-autocomplete/issues/148) [Issue 2.](https://github.com/anubra266/choc-autocomplete/issues/159)
(https://github.com/anubra266/choc-autocomplete/issues/148) Seems like the issues was because react-nany didn't handle children correctly.