### PR TITLE
Fixed description and default value of the AutoComplete submitKeys prop in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ string[]
 
 </td>
             <td>A list of <a href="https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values">KeyboardEvent: key values</a>, except for the "Enter" key, that trigger the click event of the currently selected Item.</td>
-            <td>false</td>
+            <td>&mdash;&mdash;&mdash;</td>
         </tr>
          <tr>
             <td>suggestWhenEmpty</td>

--- a/README.md
+++ b/README.md
@@ -637,7 +637,7 @@ string[]
 ```
 
 </td>
-            <td>show suggestions when input value is empty</td>
+            <td>A list of <a href="https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values">KeyboardEvent: key values</a>, except for the "Enter" key, that trigger the click event of the currently selected Item.</td>
             <td>false</td>
         </tr>
          <tr>


### PR DESCRIPTION
In the README, the `submitKeys` prop of the AutoComplete component is incorrectly described.

Before my change the `submitKeys` prop had the same description as the `suggestWhenEmpty` prop. I changed the description from: 
*show suggestions when input value is empty*
to
*A list of KeyboardEvent: key values, except for the "Enter" key, that trigger the click event of the currently selected Item.*

I also changed the default value of the prop to &mdash;&mdash;&mdash;