### PR TITLE
Fix #172 defaultValue with Array of Number

### DIFF
--- a/src/helpers/items.ts
+++ b/src/helpers/items.ts
@@ -7,7 +7,7 @@ import { Item } from "../types";
 import { AutoCompleteItemProps } from "../autocomplete-item";
 
 export const getDefItemValue = (item: AutoCompleteItemProps["value"]) =>
-  (typeof item === "string" ? item : item[Object.keys(item)[0]])?.toString();
+  (typeof item === "string" || typeof item === "number" ? item : item[Object.keys(item)[0]])?.toString();
 
 export const setEmphasis = (children: any, query: string) => {
   if (typeof children !== "string" || isEmpty(query)) {

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -118,7 +118,7 @@ export function useAutoComplete(
 
   const filteredList = [...filteredResults, ...creatableArr];
   const [values, setValues] = useControllableState({
-    defaultValue: defaultValues,
+    defaultValue: defaultValues.map(v => v?.toString()),
     value: valuesProp,
     onChange: (newValues: any[]) => {
       const item = filteredList.find(opt => opt.value === newValues[0]);
@@ -219,7 +219,7 @@ export function useAutoComplete(
 
   const tags = multiple
     ? values.map(tag => ({
-        label: itemList.find(item => item.value === tag)?.label || tag,
+        label: itemList.find(item => item.value === tag?.toString())?.label || tag,
         onRemove: () => removeItem(tag),
       }))
     : [];


### PR DESCRIPTION
Suggested fix for #172 will normalize values to a string

If your values prop and defaultValues prop contain numbers instead of strings, the wrong label is displayed on the tags and the selected items aren't highlighted correctly in the list

Proposed fix is to treat number values as strings which keeps in line with default behavior of manually selecting an item from the dropdown (newly added item will be a string) as well as what would happen if this was a regular <select> element instead.