### PR TITLE
Fix #152 support for escape and tab

### DIFF
--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -5,7 +5,6 @@ import {
   useControllableState,
 } from "@chakra-ui/react";
 import {
-  callAll,
   getFirstItem,
   getLastItem,
   getNextItem,
@@ -302,24 +301,29 @@ export function useAutoComplete(
           }
 
           if (key === "ArrowDown") {
-            setFocusedValue(nextItem?.value);
+            if(!isOpen)
+              onOpen();
+            else 
+              setFocusedValue(nextItem?.value);
             e.preventDefault();
             return;
           }
 
           if (key === "ArrowUp") {
-            setFocusedValue(prevItem?.value);
+            if(!isOpen)
+              onOpen();
+            else
+              setFocusedValue(prevItem?.value);
 
             e.preventDefault();
             return;
           }
 
           if (key === "Tab") {
-            setFocusedValue(nextItem?.value);
-
-            if (isOpen) {
-              e.preventDefault();
-            }
+            if (focusedItem && !focusedItem?.disabled)
+              selectItem(focusedItem?.value);
+            else 
+              onClose();
 
             return;
           }
@@ -337,7 +341,8 @@ export function useAutoComplete(
           }
 
           if (key === "Escape") {
-            callAll(onClose, e.preventDefault);
+            onClose();
+            e.preventDefault();
           }
         },
         value: query,


### PR DESCRIPTION
Fix for issue #152 to add back in support for escape and tab characters

Thought process:   Escape should just close the list without any further action.

**Tab functionality**

When pressing tab, it should function like a select where the currently selected item becomes the value, the select closes, and the focusable item is focused. If no value is selected, the select will simply close and focus the next item.

Replaced call to setFocusedValue with selectItem.  If no value currently selected, simply call onClose


**Escape functionality**

The escape issue appeared to be an issue with the callAll utility.  It would return a function that you can run, but I was unable to figure out how to run the function.  Replaced with calling each function individually.


**Arrow up/down**

Also fixes an issue where pressing the up/down arrow would not re-open the list if it was closed.