### PR TITLE
Fix #190 input to wrap style conversion

### DIFF
--- a/src/helpers/input.ts
+++ b/src/helpers/input.ts
@@ -1,14 +1,42 @@
-export const getMultipleWrapStyles = (themeInput: any, multiple?: boolean) => ({
-  ...(multiple && {
-    ...themeInput.field,
-    _focusWithin: themeInput.field._focus,
-    pos: "relative",
-    minH: 9,
-    // px: 3,
-    py: 1.5,
-    spacing: 3,
-  }),
-  cursor: "text",
-  h: "fit-content",
-  // w: "full",
-});
+export const getMultipleWrapStyles = (themeInput: any, multiple?: boolean) => {
+  const fieldStyles: any = {};
+  const inputOverrides: any = {};
+
+  const { field } = themeInput;
+
+  if(field) {
+    Object.keys(field)
+    .forEach(key => {
+      if(key.startsWith("--input") === false)
+        fieldStyles[key] = field[key];
+      else {
+        let value = field[key];
+        const cssPropName = key.replace("--input-", "");
+        const javascriptCssPropName = cssPropName
+          .replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+
+        if(value.indexOf('.') !== -1) {
+          value = value.substring(value.indexOf('.') + 1);
+        }
+
+        inputOverrides[javascriptCssPropName] = value;
+      }
+    });
+  }
+
+    return {
+    ...(multiple && {
+      ...fieldStyles,
+      ...inputOverrides, 
+      _focusWithin: themeInput.field._focus,
+      pos: "relative",
+      minH: 9,
+      // px: 3,
+      py: 1.5,
+      spacing: 3,
+    }),
+    cursor: "text",
+    h: "fit-content",
+    // w: "full",
+  };
+};


### PR DESCRIPTION
Fixes #190 where several invalid attribute errors would pop up when using the `multiple` attribute.

Applying this attempts to convert all of the --input* attributes that are created and then applied to the `Wrap` component.  The equivalent to these ie --input-padding: space.4 should be converted into just padding: 4.  This seems to work correctly for all of the existing errors that were happening.  I have not tested this exhaustively with every single prop that could be passed to the `Input` component and then subsequently passed on to the `Wrap` component.

This also fixes #177 which reported the same issue specifically with `_focus`