### PR TITLE
Fix #140 #150 #156 - List not displayed when parent is pre-rendered

### DIFF
--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -1,9 +1,9 @@
 import {
-  useDimensions,
   useDisclosure,
   useUpdateEffect,
   useControllableState,
 } from "@chakra-ui/react";
+import { useSize } from "@chakra-ui/react-use-size"
 import {
   getFirstItem,
   getLastItem,
@@ -352,12 +352,12 @@ export function useAutoComplete(
     };
   };
 
-  const wrapperDim = useDimensions(inputWrapperRef, true);
-  const inputDim = useDimensions(inputRef, true);
+  const wrapperDim = useSize(inputWrapperRef);
+  const inputDim = useSize(inputRef);
   const getListProps: UseAutoCompleteReturn["getListProps"] = () => {
     const width = autoCompleteProps.multiple
-      ? (wrapperDim?.marginBox.width as number)
-      : (inputDim?.marginBox.width as number);
+      ? (wrapperDim?.width as number)
+      : (inputDim?.width as number);
     return {
       width,
     };


### PR DESCRIPTION
Fix #140 
Fix #150 
Fix #156 

This should fix above issues which all seemed to suffer from the same underlying issue: if `AutoComplete` is rendered as a child of something the pre-renders content as `hidden` like `Tabs`, `Accordion`, `Collapse`, etc the width returned by `useDimensions` incorrectly states 0px.

Reading the docs, it looks like `useDimensions` was deprecated and replaced with `useSize` instead.  This new hook doesn't appear to have the same issue if the item is rendered within a parent container that is hidden.

I tested all 3 scenarios locally and this appears to work correctly.  When combined with PR #189 the content is even rendered correctly within the popover and will no longer be hidden by things like `AccordionPanel`