### PR TITLE
fix: invalid props

### DIFF
--- a/src/autocomplete-input.tsx
+++ b/src/autocomplete-input.tsx
@@ -29,11 +29,12 @@ export interface AutoCompleteInputProps extends Omit<InputProps, "children"> {
 const AutoCompleteInputComponent = forwardRef(
   (props, forwardedRef) => {
     const { isLoading } = useAutoCompleteContext();
+    const { loadingIcon, ...inputProps } = props;
 
     return <InputGroup>
-    <Input {...props} ref={forwardedRef} />
+    <Input {...inputProps} ref={forwardedRef} />
     { isLoading && <InputRightElement>
-      { props.loadingIcon || <Spinner /> }
+      { loadingIcon || <Spinner /> }
     </InputRightElement> }
   </InputGroup>;
   }

--- a/src/autocomplete-list.tsx
+++ b/src/autocomplete-list.tsx
@@ -17,7 +17,7 @@ export interface AutoCompleteListProps extends PopoverContentProps {
 
 export const AutoCompleteList = forwardRef<AutoCompleteListProps, "div">(
   (props, forwardedRef) => {
-    const { children, ...rest } = props;
+    const { children, loadingState, ...rest } = props;
     const { listRef, getListProps, isLoading } = useAutoCompleteContext();
     const ref = useMergeRefs(forwardedRef, listRef);
     const listProps = getListProps();
@@ -27,7 +27,7 @@ export const AutoCompleteList = forwardRef<AutoCompleteListProps, "div">(
       <PopoverContent ref={ref} {...baseStyles} {...listProps} {...rest}>
         { isLoading && (
           <Center>
-            { props.loadingState || <Spinner size="md" /> }
+            { loadingState || <Spinner size="md" /> }
           </Center>
         )}
         { !isLoading && (


### PR DESCRIPTION
After adding the loading props and merging some other PRs, some invalid props began being sent to the `Input` and `PopoverContent` components.  This fixes those errors by explicitly destructuring `props`