### PR TITLE
Fix closeOnSelect default

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Wrapper and Provider for `AutoCompleteInput` and `AutoCompleteList`
             <td>closeOnSelect</td>
             <td>boolean</td>
             <td>close suggestions when a suggestions is selected</td>
-            <td>true</td>
+            <td>true when multiple=false, false when multiple=true</td>
         </tr>
         <tr>
             <td>creatable</td>

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -41,7 +41,6 @@ export function useAutoComplete(
 ): UseAutoCompleteReturn {
   let {
     closeOnBlur = true,
-    closeOnSelect,
     creatable,
     emphasize,
     emptyState = true,
@@ -50,6 +49,7 @@ export function useAutoComplete(
     listAllValuesOnFocus,
     maxSuggestions,
     multiple,
+    closeOnSelect = multiple ? false : true,
     defaultValue,
     defaultValues = defaultValue ? [defaultValue] : [],
     onReady,
@@ -68,7 +68,6 @@ export function useAutoComplete(
         : [...value]
       : undefined,
   } = autoCompleteProps;
-  closeOnSelect = closeOnSelect ? closeOnSelect : multiple ? false : true;
 
   freeSolo = freeSolo ? freeSolo : multiple ? true : autoCompleteProps.freeSolo;
 


### PR DESCRIPTION
When multiple=true, should default to false.  When multiple=false, should default to true

Fix #145