### PR TITLE
perf: reduce AutoComplete renders

### DIFF
--- a/src/autocomplete-list.tsx
+++ b/src/autocomplete-list.tsx
@@ -18,13 +18,12 @@ export interface AutoCompleteListProps extends PopoverContentProps {
 export const AutoCompleteList = forwardRef<AutoCompleteListProps, "div">(
   (props, forwardedRef) => {
     const { children, loadingState, ...rest } = props;
-    const { listRef, getListProps, isLoading } = useAutoCompleteContext();
+    const { listRef, isLoading } = useAutoCompleteContext();
     const ref = useMergeRefs(forwardedRef, listRef);
-    const listProps = getListProps();
     const [autoCompleteItems, nonAutoCompleteItems] = siblingInfo(children);
 
     return (
-      <PopoverContent ref={ref} {...baseStyles} {...listProps} {...rest}>
+      <PopoverContent ref={ref} w='inherit' {...baseStyles} {...rest}>
         { isLoading && (
           <Center>
             { loadingState || <Spinner size="md" /> }

--- a/src/autocomplete.tsx
+++ b/src/autocomplete.tsx
@@ -44,6 +44,7 @@ export const AutoComplete = forwardRef<AutoCompleteProps, "div">(
           autoFocus={false}
           placement={placement}
           closeOnBlur={true}
+          matchWidth={true}
         >
           <chakra.div
             w="full"

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,7 +134,6 @@ export type UseAutoCompleteReturn = {
     props: AutoCompleteItemProps,
     creatable?: boolean
   ) => ItemReturnProps;
-  getListProps: () => ListReturnProps;
   inputRef: React.RefObject<HTMLInputElement>;
   interactionRef: React.RefObject<"mouse" | "keyboard" | null>;
   isOpen: boolean;

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -3,7 +3,6 @@ import {
   useUpdateEffect,
   useControllableState,
 } from "@chakra-ui/react";
-import { useSize } from "@chakra-ui/react-use-size"
 import {
   getFirstItem,
   getLastItem,
@@ -353,17 +352,6 @@ export function useAutoComplete(
     };
   };
 
-  const wrapperDim = useSize(inputWrapperRef);
-  const inputDim = useSize(inputRef);
-  const getListProps: UseAutoCompleteReturn["getListProps"] = () => {
-    const width = autoCompleteProps.multiple
-      ? (wrapperDim?.width as number)
-      : (inputDim?.width as number);
-    return {
-      width,
-    };
-  };
-
   const getItemProps: UseAutoCompleteReturn["getItemProps"] = (
     props,
     creatable
@@ -467,7 +455,6 @@ export function useAutoComplete(
     getGroupProps,
     getInputProps,
     getItemProps,
-    getListProps,
     inputRef,
     interactionRef,
     isLoading, 


### PR DESCRIPTION
Reduces render of AutoComplete component by 2 for each action:

initial render, open, close, select, etc

Initial render performance increase

AutoComplete = 3 => 1
AutoCompleteList = 3 => 1
AutoCompleteInput = 3 => 2

Accomplished by removing need for getListProps which depends on useSize

Per below issue, the matchWidth prop correctly calculates width
width=inherit needs to be passed to PopoverContent

https://github.com/chakra-ui/chakra-ui/issues/4104