### PR TITLE
Make prefocusFirstItem behavior configurable and consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 </a>
     <br />
     AutoComplete Component for the <a href="https://chakra-ui.com">Chakra UI</a> Library.</em>
-    
+
   </sup>
   <br />
   <br />
@@ -454,6 +454,12 @@ Wrapper and Provider for `AutoCompleteInput` and `AutoCompleteList`
             <td>Suggestions list is open by default</td>
             <td>false</td>
         </tr>
+        <tr>
+            <td>prefocusFirstItem</td>
+            <td>boolean</td>
+            <td>Should prefocus first item intially, on query change, on open, and on filter out of current focused item</td>
+            <td>true</td>
+        </tr>
          <tr>
             <td>defaultValues</td>
             <td>Array</td>
@@ -560,7 +566,7 @@ boolean | MaybeRenderProp<{ value: Item["value"] }>
         <tr>
             <td>onSelectOption</td>
             <td>
-            
+
 ```ts
 (params: {
     item: Item;
@@ -591,7 +597,7 @@ boolean | MaybeRenderProp<{ value: Item["value"] }>
         <tr>
             <td>onReady</td>
             <td>
-            
+
 ```ts
 (props:{tags:ItemTag[]}) => void
 ```
@@ -602,7 +608,7 @@ boolean | MaybeRenderProp<{ value: Item["value"] }>
         <tr>
             <td>onTagRemoved</td>
             <td>
-            
+
 ```ts
 (removedTag: Item["value"],item: Item, tags: Item["value"][]) => void
 ```
@@ -643,7 +649,7 @@ boolean | MaybeRenderProp<{ value: Item["value"] }>
         <tr>
             <td>shouldRenderSuggestions</td>
             <td>
-            
+
 ```ts
 (value: string) => boolean
 ```
@@ -731,7 +737,7 @@ Tags for multiple mode
     <td>Yes<br></td>
     <td>&mdash;&mdash;&mdash;</td>
   </tr>
- 
+
 </tbody>
 </table>
 
@@ -782,7 +788,7 @@ e.g.
     <td>No<br></td>
     <td>&mdash;&mdash;&mdash;</td>
   </tr>
-  
+
   <tr>
     <td>ref</td>
     <td>
@@ -1020,7 +1026,7 @@ val => val;
 ```
 
 </td>
-</tr> 
+</tr>
 </tbody>
 </table>
 
@@ -1085,7 +1091,7 @@ When true, `AutoCompleteCreatable` is shown even when the `AutoCompleteInput` is
     <td>No<br></td>
     <td>&mdash;&mdash;&mdash;</td>
   </tr>
- 
+
 </tbody>
 </table>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,16 +2,16 @@ import {
   BoxProps,
   FlexProps,
   InputProps,
+  PlacementWithLogical,
   SystemStyleObject,
-  WrapProps,
-  PlacementWithLogical
+  WrapProps
 } from "@chakra-ui/react";
 import { MaybeRenderProp } from "@chakra-ui/react-utils";
 import React, { Dispatch, SetStateAction } from "react";
 
+import { AutoCompleteProps } from "./autocomplete";
 import { AutoCompleteGroupProps } from "./autocomplete-group";
 import { AutoCompleteInputProps } from "./autocomplete-input";
-import { AutoCompleteProps } from "./autocomplete";
 import { AutoCompleteItemProps } from "./autocomplete-item";
 
 export interface Item {
@@ -28,6 +28,7 @@ export interface Item {
 export type UseAutoCompleteProps = Partial<{
   closeOnBlur: boolean;
   closeOnSelect: boolean;
+  prefocusFirstItem: boolean
   creatable: boolean;
   defaultIsOpen: boolean;
   defaultValue: Item["value"];


### PR DESCRIPTION
# Problem
Most of the time, this component tends to prefocuses first suggestion. This is done in a way that in not configurable and slightly inconsistent. For example, if you want to match behavior of Google Autocomplete on this aspect, you can't (GAC doesn't prefocus first item).

# Before Change
- It prefocuses first item in most cases
  - On initially render
  - On query change
  - On open
  - NOT on filter out of currently focused item
 
# After Change
- When prefocusFirstItem is true (default)
  - On initially render
  - On query change
  - On open
  - On on filter out of currently focused item
- When false
  - Do not prefocus on all events above
