### PR TITLE
Fix `value` prop does nothing

### DIFF
--- a/src/autocomplete-input.tsx
+++ b/src/autocomplete-input.tsx
@@ -67,7 +67,7 @@ export const AutoCompleteInput = forwardRef<AutoCompleteInputProps, "input">(
       if(value !== undefined && (typeof value === 'string' || value instanceof String)) {
         const item = itemList.find(l => l.value === value);
 
-        const newQuery = item === undefined ? '' : item.label;
+        const newQuery = item === undefined ? value : item.label;
 
         setQuery(newQuery);
       }

--- a/src/autocomplete-input.tsx
+++ b/src/autocomplete-input.tsx
@@ -47,7 +47,9 @@ export const AutoCompleteInput = forwardRef<AutoCompleteInputProps, "input">(
       inputRef,
       getInputProps,
       tags,
-      setQuery
+      setQuery, 
+      value, 
+      itemList
     } = useAutoCompleteContext();
 
     // const ref = useMergeRefs(forwardedRef, inputRef);
@@ -59,13 +61,23 @@ export const AutoCompleteInput = forwardRef<AutoCompleteInputProps, "input">(
       ...rest
     } = props;
 
-    const { value } = rest;
+    const { value: inputValue } = rest;
 
     useEffect(() => {
       if(value !== undefined && (typeof value === 'string' || value instanceof String)) {
-        setQuery(value);
+        const item = itemList.find(l => l.value === value);
+
+        const newQuery = item === undefined ? '' : item.label;
+
+        setQuery(newQuery);
       }
     }, [value]);
+
+    useEffect(() => {
+      if(inputValue !== undefined && (typeof inputValue === 'string' || inputValue instanceof String)) {
+        setQuery(inputValue);
+      }
+    }, [inputValue]);
 
     const themeInput: any = useMultiStyleConfig("Input", props);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,7 @@ export type UseAutoCompleteReturn = {
   resetItems: (focusInput?: boolean) => void;
   setQuery: Dispatch<SetStateAction<any>>;
   tags: ItemTag[];
+  value: Item["value"];
   values: Item["value"][];
 };
 

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -487,6 +487,7 @@ export function useAutoComplete(
     resetItems,
     setQuery,
     tags,
+    value, 
     values,
   };
 }


### PR DESCRIPTION
# Problem
According to the documentation, the `value` prop is supposed to make the component act like a controlled input.  It doesn't appear to do anything.

# Before Change
In order for a truly controlled component, you had to pass `value` to both `AutoComplete` and `AutoCompleteInput`.  While this worked, it caused a lot of confusion with how the component worked.  It also had the unintended consequence of making `AutoCompleteInput` always display the current value rather than the label of the item that was passed in.
 
# After Change
Passing `value` to `AutoComplete` will now make this a controlled input as described by the documentation.  If the `value` is changed outside of component, the `AutoCompleteInput` will correctly update with the label associated with the new `value`

Fixes #235 