### PR TITLE
Fix issues with removeItem

### DIFF
--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -188,11 +188,14 @@ export function useAutoComplete(
   }, [focusedValue, autoCompleteProps.onOptionFocus]);
 
   const selectItem = (optionValue: Item["value"]) => {
+    const option = filteredList.find(i => i.value === optionValue);
+
+    const optionLabel = option?.label || option?.value;
+    setQuery(() => (multiple ? "" : optionLabel ?? ""));
+
     if (!values.includes(optionValue) && values.length < maxSelections) {
       setValues(v => (multiple ? [...v, optionValue] : [optionValue]));
     }
-
-    const option = filteredList.find(i => i.value === optionValue);
 
     if (multiple) {
       inputRef.current?.focus();
@@ -210,9 +213,6 @@ export function useAutoComplete(
       });
     }
 
-    const optionLabel = option?.label || option?.value;
-    setQuery(() => (multiple ? "" : optionLabel ?? ""));
-
     if (closeOnSelect) onClose();
   };
 
@@ -228,7 +228,7 @@ export function useAutoComplete(
 
     const item = itemList.find(opt => opt.value === itemValue);
     const itemLabel = item?.label || item?.value;
-    
+
     if (query === itemLabel) setQuery("");
     if (focusInput) inputRef.current?.focus();
   };

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -225,7 +225,11 @@ export function useAutoComplete(
       runIfFn(autoCompleteProps.onTagRemoved, itemValue, item, prevValues);
       return prevValues.filter(i => i !== itemValue);
     });
-    if (query === itemValue) setQuery("");
+
+    const item = itemList.find(opt => opt.value === itemValue);
+    const itemLabel = item?.label || item?.value;
+    
+    if (query === itemLabel) setQuery("");
     if (focusInput) inputRef.current?.focus();
   };
 


### PR DESCRIPTION
`removeItem` did not behave as expected.  There were 2 separate issues.

* If the value passed in did not match the label being displayed, it did not function correctly
* `onChange` was being called before the value of the `query` being displayed in the input changed, so it wouldn't be possible to remove what was selected

Fixes #247