### PR TITLE
Fix: named export error due to build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.es.js",
+  "type": "module", 
   "files": [
     "dist"
   ],

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import tsConfigPaths from 'vite-tsconfig-paths';
 
 import { peerDependencies as externals, name } from './package.json';
 
-module.exports = defineConfig(() => ({
+export default defineConfig(() => ({
   plugins: [
     react(),
     tsConfigPaths(),


### PR DESCRIPTION
Update build process to use export default and type module.  This fixes an issue where under some setups you would receive a named export error

Fixes #241 