### PR TITLE
252ExposeMaxWidth

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,12 @@ boolean | MaybeRenderProp<{ value: Item["value"] }>
             <td>Show all suggestions when user focuses the input, while it's not empty.</td>
             <td>false</td>
         </tr>
+         <tr>
+            <td>matchWidth</td>
+            <td>boolean</td>
+            <td>Chakra UI Popover.matchWidth property to match the popover content's width to the width of the container</td>
+            <td>true</td>
+        </tr>
         <tr>
             <td>maxSelections</td>
             <td>number</td>

--- a/src/autocomplete.tsx
+++ b/src/autocomplete.tsx
@@ -34,6 +34,8 @@ export const AutoComplete = forwardRef<AutoCompleteProps, "div">(
       removeItem,
     }));
 
+    const { matchWidth = true } = context.autoCompleteProps;
+
     return (
       <AutoCompleteProvider value={context}>
         <Popover
@@ -44,7 +46,7 @@ export const AutoComplete = forwardRef<AutoCompleteProps, "div">(
           autoFocus={false}
           placement={placement}
           closeOnBlur={true}
-          matchWidth={true}
+          matchWidth={matchWidth}
         >
           <chakra.div
             w="full"

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,6 +46,7 @@ export type UseAutoCompleteProps = Partial<{
   isLoading: boolean,
   isReadOnly: boolean;
   listAllValuesOnFocus: boolean;
+  matchWidth: boolean;
   maxSelections: number;
   maxSuggestions: number;
   multiple: boolean;


### PR DESCRIPTION
Adds a new property called `matchWidth` which is passed directly to the Chakra UI Popover `matchWidth` prop.  Defaults to true

#252