### PR TITLE
Changed scrollIntoView behaviour to fix scrolling issue when navigating with keyboard

### DIFF
--- a/src/autocomplete-item.tsx
+++ b/src/autocomplete-item.tsx
@@ -39,7 +39,7 @@ export const AutoCompleteItem = forwardRef<AutoCompleteItemProps, "div">(
       if (isFocused && interactionRef.current === "keyboard")
         itemRef?.current?.scrollIntoView({
           behavior: "smooth",
-          block: "center",
+          block: "nearest",
         });
     }, [isFocused, interactionRef]);
 


### PR DESCRIPTION
This PR fixes a bug that causes the window to constantly scroll when navigating with the keyboard. This was caused by the following useEffect:

      if (isFocused && interactionRef.current === "keyboard")
        itemRef?.current?.scrollIntoView({
          behavior: "smooth",
          block: "center",
        });
    }, [isFocused, interactionRef]);
I assume the intention here was to make the selected element visible when you pressed the keyboard. But because the block variable is set to "center", the browser will try to move the item to the center of the window every time the keyboard is pressed.

Changing this to block: "nearest" changes the behaviour so it only scrolls the screen if the selected element isn't visible. 

Fixes #253