### PR TITLE
fix: reset the focus of the first item when the list changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.5.2",
+  "version": "5.5.2-fixed-10",
   "license": "MIT",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -15,7 +15,7 @@ import {
   runIfFn,
 } from "@chakra-ui/utils";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AutoCompleteProps } from "./autocomplete";
 import { hasChildren, hasFirstItem, hasLastItem } from "./helpers/group";
@@ -78,7 +78,7 @@ export function useAutoComplete(
     onClose,
     onOpen,
   });
-  const itemList: Item[] = getItemList(children);
+  const itemList: Item[] = useMemo(() => getItemList(children), [children]);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const inputWrapperRef = useRef<HTMLDivElement>(null);
@@ -93,7 +93,8 @@ export function useAutoComplete(
   else if (!isUndefined(valuesProp)) defaultQuery = valuesProp[0];
 
   const [query, setQuery] = useState<string>(defaultQuery ?? "");
-  const filteredResults = disableFilter
+  const filteredResults = useMemo(() => 
+    disableFilter
     ? itemList
     : itemList
         .filter(
@@ -109,14 +110,14 @@ export function useAutoComplete(
         )
         .filter((i, index) =>
           maxSuggestions ? i.fixed || index < maxSuggestions : true
-        );
+        ), [query, itemList, listAll, maxSuggestions, disableFilter]);
 
   // Add Creatable to Filtered List
   const creatableArr: Item[] = creatable
     ? [{ value: query, noFilter: true, creatable: true }]
     : [];
 
-  const filteredList = [...filteredResults, ...creatableArr];
+  const filteredList = useMemo(() => [...filteredResults, ...creatableArr], [filteredResults, creatableArr]);
   const [values, setValues] = useControllableState({
     defaultValue: defaultValues.map(v => v?.toString()),
     value: valuesProp,

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -73,11 +73,11 @@ export function useAutoComplete(
 
   const { isOpen, onClose, onOpen } = useDisclosure({ defaultIsOpen });
 
-  const children = runIfFn(autoCompleteProps.children, {
+  const children = useMemo(() => runIfFn(autoCompleteProps.children, {
     isOpen,
     onClose,
     onOpen,
-  });
+  }), [autoCompleteProps.children, isOpen]);
   const itemList: Item[] = useMemo(() => getItemList(children), [children]);
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -112,12 +112,14 @@ export function useAutoComplete(
           maxSuggestions ? i.fixed || index < maxSuggestions : true
         ), [query, itemList, listAll, maxSuggestions, disableFilter]);
 
-  // Add Creatable to Filtered List
-  const creatableArr: Item[] = creatable
-    ? [{ value: query, noFilter: true, creatable: true }]
-    : [];
+  const filteredList = useMemo(() => {
+    // Add Creatable to Filtered List
+    const creatableArr: Item[] = creatable
+      ? [{ value: query, noFilter: true, creatable: true }]
+      : [];
 
-  const filteredList = useMemo(() => [...filteredResults, ...creatableArr], [filteredResults, creatableArr]);
+    return [...filteredResults, ...creatableArr]
+  }, [filteredResults]);
   const [values, setValues] = useControllableState({
     defaultValue: defaultValues.map(v => v?.toString()),
     value: valuesProp,

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -112,14 +112,14 @@ export function useAutoComplete(
           maxSuggestions ? i.fixed || index < maxSuggestions : true
         ), [query, itemList, listAll, maxSuggestions, disableFilter]);
 
-  const filteredList = useMemo(() => {
     // Add Creatable to Filtered List
-    const creatableArr: Item[] = creatable
-      ? [{ value: query, noFilter: true, creatable: true }]
-      : [];
+  const creatableArr: Item[] = creatable
+    ? [{ value: query, noFilter: true, creatable: true }]
+    : [];
 
+  const filteredList = useMemo(() => {
     return [...filteredResults, ...creatableArr]
-  }, [filteredResults]);
+  }, [filteredResults, creatableArr]);
   const [values, setValues] = useControllableState({
     defaultValue: defaultValues.map(v => v?.toString()),
     value: valuesProp,

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -171,7 +171,7 @@ export function useAutoComplete(
   useUpdateEffect(() => {
     if (prefocusFirstItem)
       setFocusedValue(firstItem?.value);
-  }, [query]);
+  }, [query, firstItem]);
 
   useEffect(() => {
     if (!isOpen && prefocusFirstItem)


### PR DESCRIPTION
The focus of the first item should be reseted also when the list changes:

`
  useUpdateEffect(() => {
    if (prefocusFirstItem)
      setFocusedValue(firstItem?.value);
  }, [query, firstItem]);
`

This happens specially when the source data comes from an API and the list constantly changes.

Fixes: #257 