### PR TITLE
fix set focused value when first item changes

### DIFF
--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -175,7 +175,7 @@ export function useAutoComplete(
   useUpdateEffect(() => {
     if (prefocusFirstItem)
       setFocusedValue(firstItem?.value);
-  }, [query, firstItem]);
+  }, [query, firstItem?.value]);
 
   useEffect(() => {
     if (!isOpen && prefocusFirstItem)


### PR DESCRIPTION
### Issue
Sometimes the `firstItem` is the same but it goes inside the effect causing a reset on the focused value even when neither the list nor the query has changed.

### Fix
Pass only `firstItem?.value` to the dependencies array.
