### PR TITLE
fix: close state when `emptyState` is false and there is no suggestions

### DIFF
--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -138,11 +138,10 @@ export function useAutoComplete(
   });
 
   useEffect(() => {
-    if(filteredList.length === 0 && !emptyState) {
+    if(filteredList.length === 0 && !emptyState && isOpen) {
       onClose();
     }
-
-  }, [filteredList.length]);
+  }, [filteredList.length, emptyState, isOpen]);
 
   const [focusedValue, setFocusedValue] = useState<Item["value"]>(
     prefocusFirstItem

--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -137,6 +137,13 @@ export function useAutoComplete(
     },
   });
 
+  useEffect(() => {
+    if(filteredList.length === 0 && !emptyState) {
+      onClose();
+    }
+
+  }, [filteredList.length]);
+
   const [focusedValue, setFocusedValue] = useState<Item["value"]>(
     prefocusFirstItem
       ? itemList[0]?.value
@@ -476,6 +483,7 @@ export function useAutoComplete(
         : runIfFn(emptyState, { query });
     }
   };
+
 
   return {
     autoCompleteProps,


### PR DESCRIPTION
I encored a bug, when the `emptyState` is `false` and there is no suggestion and the suggestion box was already open, it will show an empty suggestion box.

```tsx
<AutoComplete emptyState={false}>
...
```

This small fix closes the suggestion box, in that case