### PR TITLE
Don't bundle react/jsx-runtime (fixes React 19)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -22,7 +22,7 @@ export default defineConfig(() => ({
       formats: ['cjs', 'es'],
     },
     rollupOptions: {
-      external: Object.keys(externals),
+      external: ["react/jsx-runtime", ...Object.keys(externals)],
     },
   },
 }));


### PR DESCRIPTION
Currently, the bundle produced by `yarn build` includes the production and development versions of the react jsx runtime.

This PR adds the (internal) `react/jsx-runtime` package to the `rollupOptions` external field, which excludes it from bundling.

Bundling the jsx runtime is not a problem as long as the importing application is using the same version of react as `choc-autocomplete`, i.e. 18, but when importing from an application using react 19, it will error out.

Additionally, this cuts the bundle size in ~half.


### Before
```
❯ yarn build
yarn run v1.22.22
$ vite build
vite v5.4.11 building for production...
✓ 41 modules transformed.

[vite:dts] Start generate declaration files...
dist/index.js  29.58 kB │ gzip: 11.39 kB
[vite:dts] Declaration files built in 2018ms.

dist/index.es.js  44.43 kB │ gzip: 13.39 kB
✓ built in 2.19s
✨  Done in 3.63s.
```

### After
```
❯ yarn build
yarn run v1.22.22
$ vite build
vite v5.4.11 building for production...
✓ 33 modules transformed.

[vite:dts] Start generate declaration files...
dist/index.js  15.58 kB │ gzip: 6.17 kB
[vite:dts] Declaration files built in 1949ms.

dist/index.es.js  22.80 kB │ gzip: 7.27 kB
✓ built in 2.10s
✨  Done in 3.09s.
```
