### PR TITLE
chore: Updated peerDependency for react 19 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "peerDependencies": {
     "@chakra-ui/react": "^3.2.2",
     "@emotion/react": "^11.13.5",
-    "react": "^18.2.0"
+    "react": ">=18.2.0"
   },
   "dependencies": {
     "next-themes": "^0.4.3",


### PR DESCRIPTION
#285 

Relax React `peerDependency` from `^18.2.0` to `>=18.2.0` to support React 19, while still remaining compatible with React 18.

This solves the following `ERESOLVE` error when using `@choc-ui/chakra-autocomplete@"^6.0.0"` as sa dependency from a  React 19 project:

![image](https://github.com/user-attachments/assets/481f0e78-0940-49c2-87c3-cfd54a06ddbd)
