### PR TITLE
fix: select the correct item on `Enter` keypress in the multiple mode

### DIFF
--- a/src/use-autocomplete.ts
+++ b/src/use-autocomplete.ts
@@ -131,7 +131,7 @@ export function useAutoComplete(
     defaultValue: defaultValues.map(v => v?.toString()),
     value: valuesProp,
     onChange: (newValues: any[]) => {
-      const item = filteredList.find(opt => opt.value === newValues[0]);
+      const item = filteredList.find(opt => opt.value === newValues.at(-1));
       if (!item) return;
       const items = newValues.map(val =>
         filteredList.find(opt => opt.value === val)
@@ -241,7 +241,7 @@ export function useAutoComplete(
       if(!item && creatable === true) {
         item = {label: itemValue, value: itemValue};
       }
-      
+
       if (!item) {
         return prevValues;
       }
@@ -389,7 +389,7 @@ export function useAutoComplete(
         },
         value: query,
         //variant: multiple ? "unstyled" : variant,
-        variant, 
+        variant,
         ...rest,
       },
     };


### PR DESCRIPTION
### Issue
When the `multiple` mode is enabled, and there is something in the input to filter the list, the `Enter` key press does not trigger the `onChange` with the focused item.

### Fix
Since the new values are pushed to the end of the values array, it would be correct to check the last element instead of the first one in the `onChange` callback of the `values` state in the `useAutoComplete` hook.

P.S. It would be nice to have it backported to v5 as well.