### PR TITLE
fix: apply full width to popover anchor #103

### DIFF
--- a/src/autocomplete-input.tsx
+++ b/src/autocomplete-input.tsx
@@ -116,7 +116,7 @@ export const AutoCompleteInput = forwardRef<HTMLInputElement, AutoCompleteInputP
     );
 
     return (
-      <PopoverAnchor>
+      <PopoverAnchor w="full">
         {autoCompleteProps.multiple ? multipleInput : simpleInput}
       </PopoverAnchor>
     );


### PR DESCRIPTION
When using ChakraUI `<InputGroup endElement={} />`, the `<PopoverAnchor />` prevents the `<AutoCompleteInput />` from spanning the appropriate width.

```typescript
<Box border="1px solid #dddddd" w="400px">
  <AutoComplete>
    <InputGroup endElement={"X"}>
      <AutoCompleteInput variant="subtle" />
    </InputGroup>
  </AutoComplete>
</Box>
```
<img width="434" height="290" alt="image" src="https://github.com/user-attachments/assets/532e230e-9b28-4500-b04d-bb658894e9d6" />

With `PopoverAnchor` given full width:

<img width="431" height="299" alt="image" src="https://github.com/user-attachments/assets/9865c425-b3b9-4353-ae76-35e3536fe9a1" />

