### PR TITLE
fix: #297 input loses focus when changing isLoading

### DIFF
--- a/src/autocomplete-input.tsx
+++ b/src/autocomplete-input.tsx
@@ -27,17 +27,17 @@ const AutoCompleteInputComponent = forwardRef<HTMLInputElement, AutoCompleteInpu
 
   const inputProps = omit(restProps, ['children', 'wrapStyles', 'hidePlaceholder']);
 
-  const inputElement = <Input {...inputProps} ref={forwardedRef} />;
+  let endElement = undefined;
 
-  if(isLoading) {
-    return (
-      <InputGroup w="full" endElement={loadingIcon || <Spinner />}>
-        {inputElement}
-      </InputGroup>
-    );
+  if (isLoading) {
+    endElement = loadingIcon ? loadingIcon : <Spinner />;
   }
 
-  return inputElement;
+  return (
+    <InputGroup w="full" endElement={<>{endElement}</>}>
+      <Input {...inputProps} ref={forwardedRef} />
+    </InputGroup>
+  );
 });
 
 export const AutoCompleteInput = forwardRef<HTMLInputElement, AutoCompleteInputProps>(


### PR DESCRIPTION
The issue was caused by the `Input` being wrapped by an `InputGroup` when the loading state needed to be shown and not being wrapped by an `InputGroup` when the loading state did not need to be shown.

This would cause the `Input` to lose focus causing a bad UX.  We will now always render an `InputGroup` and pass the `endElement` prop based on the `isLoading` prop.

For consideration:

If you have a custom icon being displayed, the loading state will still display correctly but it looks weird because you will have 2 icons on top of each other.  Because of this, I am considering removing the `isLoading` and `loadingState` props in v7.  These should probably be external concerns that the users control themselves.

For what it's worth, the Chakra UI `Combobox` component functions this way where the loading state is something controlled and displayed externally.

https://chakra-ui.com/docs/components/combobox#async-loading

This fixes #297